### PR TITLE
Update Opal link and bump to top

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,11 +116,11 @@
       <tr>
         <th>Ruby</th>
         <td class="yay">
+          <a href="http://opalrb.org">Opal</a>
           <a href="http://hotruby.yukoba.jp/">HotRuby</a>
           <a href="https://github.com/whitequark/coldruby">ColdRuby</a>
           <a href="http://rb2js.rubyforge.org/">rb2js</a>
           <a href="https://github.com/jessesielaff/red">Red</a>
-          <a href="https://github.com/adambeynon/opal">Opal</a>
           <a href="https://github.com/mattknox/8ball">8ball</a>
         </td>
         <td class="yay"><a href="http://rubyforge.org/projects/ruby2c/">ruby2c</a></td>
@@ -205,7 +205,7 @@
           <a href="http://nakkaya.com/2011/06/29/ferret-an-experimental-clojure-compiler/">Ferret</a>
         </td>
         <td class="yay"><a href="http://clojure.org">Clojure</a></td>
-        <td class="yay"><a href="https://github.com/rouge-lang/rouge.git">rouge</a></td>
+        <td class="yay"><a href="https://github.com/unnali/rouge.git">rouge</a></td>
         <td class="yay"><a href="https://github.com/rodnaph/clj-php">clj-php</a></td>
         <td class="yay"><a href="http://clojure.org">Clojure</a></td>
         <td class="yay"><a href="https://github.com/richhickey/clojure-clr">clojure-clr</a></td>


### PR DESCRIPTION
(Opal is the only one still maintained)
