### PR TITLE
Add Cython to list of Python via C

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,6 +232,7 @@
           <a href="https://github.com/DenerosArmy/pythonscript">PythonScript</a>
         </td> <!--Python via JS-->
         <td class="yay">
+          <a href="http://cython.org">Cython</a>
           <a href="http://nuitka.net/">Nuitka</a>
           <a href="http://code.google.com/p/shedskin/">shedskin</a>
           <a href="https://github.com/pradyun/Py2C">Py2C</a>


### PR DESCRIPTION
[Cython](http://cython.org) is a popular and effective way to compile python to C.
